### PR TITLE
docs: add robots.txt file for search engine crawling

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://divesh-kumar-dev.vercel.app/sitemap.xml


### PR DESCRIPTION
Include basic configuration to allow all search engines to crawl the site and reference the sitemap