### PR TITLE
feat: add cookie consent banner component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import { generateStructuredData, generatePersonSchema, generatePortfolioSchema }
 import { generateToken } from "@/lib/csrf"
 import { applyFingerprintProtection } from '@/lib/fingerprint-protection'
 import { Toaster } from "@/components/ui/toaster"
+import CookieConsent from "@/components/cookie-consent"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -62,6 +63,7 @@ export default function RootLayout({
 					{children}
 					<FloatingNav />
 					<Toaster />
+					<CookieConsent />
 				</ThemeProvider>
 			</body>
 		</html>

--- a/components/cookie-consent.tsx
+++ b/components/cookie-consent.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+export default function CookieConsent() {
+	const [isVisible, setIsVisible] = useState(false);
+
+	useEffect(() => {
+		// Check if the user has already accepted cookies
+		const consent = localStorage.getItem('cookie_consent');
+		if (!consent) {
+			setIsVisible(true);
+		}
+	}, []);
+
+	const handleAccept = () => {
+		// Set consent in local storage and hide the banner
+		localStorage.setItem('cookie_consent', 'accepted');
+		setIsVisible(false);
+	};
+
+	if (!isVisible) {
+		return null;
+	}
+
+	return (
+		<div className="fixed bottom-0 left-0 right-0 z-50 p-4">
+			<Card className="max-w-md mx-auto shadow-lg">
+				<CardContent className="flex items-center justify-between p-4">
+					<p className="text-sm text-muted-foreground">
+						We use cookies to ensure you get the best experience on our website.
+					</p>
+					<Button onClick={handleAccept} size="sm">
+						Accept
+					</Button>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}


### PR DESCRIPTION
Implement a cookie consent banner that appears when users first visit the site and persists their choice in localStorage. The banner includes an accept button and disappears once accepted.